### PR TITLE
fix: remove hardcoded JWT secret default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# Required
-JWT_SECRET=change-me
+# Required — generate with: python3 -c "import secrets; print(secrets.token_hex(64))"
+JWT_SECRET=
 
 # Image provider: "mock" | "openai_dalle" | "gemini"
 IMAGE_PROVIDER=mock

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,8 +1,9 @@
+from pydantic import Field
 from pydantic_settings import BaseSettings
 
 
 class Settings(BaseSettings):
-    jwt_secret: str = "change-me"
+    jwt_secret: str = Field(min_length=32)
     jwt_algorithm: str = "HS256"
 
     image_provider: str = "mock"  # "mock" | "openai_dalle" | "gemini"


### PR DESCRIPTION
## Summary
- Remove weak `"change-me"` default from `jwt_secret` in `config/settings.py` — app now fails on startup if `JWT_SECRET` is not set in `.env`
- Update `.env.example` with a generation command instead of a placeholder value

## Test plan
- [x] All 48 tests pass
- [ ] Verify app refuses to start without `JWT_SECRET` set
- [ ] Verify app starts normally with `JWT_SECRET` in `.env`

Closes #6