### PR TITLE
fix: disable Swagger UI and OpenAPI spec in production

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -17,6 +17,8 @@ class Settings(BaseSettings):
 
     cors_allowed_origins: list[str] = []
 
+    debug: bool = False
+
     host: str = "0.0.0.0"
     port: int = 8100
 

--- a/main.py
+++ b/main.py
@@ -49,7 +49,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     yield
 
 
-app = FastAPI(title="GIRAF AI", version="0.1.0", lifespan=lifespan)
+app = FastAPI(
+    title="GIRAF AI",
+    version="0.1.0",
+    lifespan=lifespan,
+    docs_url="/docs" if settings.debug else None,
+    redoc_url=None,
+    openapi_url="/openapi.json" if settings.debug else None,
+)
 
 if settings.cors_allowed_origins:
     app.add_middleware(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,6 +101,11 @@ def test_generate_image_provider_error_returns_502(
     assert "boom" in resp.json()["detail"]
 
 
+def test_docs_disabled_by_default(client: TestClient) -> None:
+    assert client.get("/docs").status_code == 404
+    assert client.get("/openapi.json").status_code == 404
+
+
 def test_tts_provider_error_returns_502(client: TestClient, auth_header: dict[str, str]) -> None:
     with patch(
         "services.tts_service.TTSService.synthesize",


### PR DESCRIPTION
## Summary
- Adds `DEBUG` setting (default: `false`)
- `/docs` and `/openapi.json` only served when `DEBUG=true`
- `/redoc` always disabled

Closes #2

## Configuration
Set `DEBUG=true` in `.env` for local development to re-enable Swagger UI.

## Test plan
- [x] Existing tests pass
- [x] New test verifies `/docs` and `/openapi.json` return 404 by default