### PR TITLE
fix: make provider base URLs configurable via environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,15 @@ JWT_SECRET=
 # Image provider: "mock" | "openai_dalle" | "gemini"
 IMAGE_PROVIDER=mock
 OPENAI_API_KEY=
+OPENAI_BASE_URL=https://api.openai.com/v1
 GEMINI_API_KEY=
+GEMINI_BASE_URL=https://generativelanguage.googleapis.com/v1beta
 GEMINI_MODEL=gemini-2.5-flash-image
 
 # TTS provider: "mock" | "google_tts" | "gemini_tts"
 TTS_PROVIDER=mock
 GOOGLE_TTS_CREDENTIALS=
+GOOGLE_TTS_BASE_URL=https://texttospeech.googleapis.com/v1
 GEMINI_TTS_MODEL=gemini-2.5-flash-preview-tts
 
 # Server

--- a/adapters/image/gemini.py
+++ b/adapters/image/gemini.py
@@ -17,10 +17,15 @@ _ASPECT_RATIO_MAP = {
 
 
 class GeminiImageAdapter(ImageGeneratorPort):
-    def __init__(self, api_key: str, model: str = "gemini-2.5-flash-image") -> None:
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gemini-2.5-flash-image",
+        base_url: str = "https://generativelanguage.googleapis.com/v1beta",
+    ) -> None:
         self._model = model
         self._client = httpx.AsyncClient(
-            base_url="https://generativelanguage.googleapis.com/v1beta",
+            base_url=base_url,
             headers={"x-goog-api-key": api_key},
             timeout=60.0,
         )

--- a/adapters/image/openai_dalle.py
+++ b/adapters/image/openai_dalle.py
@@ -14,10 +14,10 @@ _SIZE_MAP = {
 
 
 class OpenAIDalleAdapter(ImageGeneratorPort):
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, base_url: str = "https://api.openai.com/v1") -> None:
         self._api_key = api_key
         self._client = httpx.AsyncClient(
-            base_url="https://api.openai.com/v1",
+            base_url=base_url,
             headers={"Authorization": f"Bearer {api_key}"},
             timeout=60.0,
         )

--- a/adapters/tts/gemini_tts.py
+++ b/adapters/tts/gemini_tts.py
@@ -37,10 +37,15 @@ def _pcm_to_wav(pcm: bytes, sample_rate: int = 24000) -> bytes:
 
 
 class GeminiTTSAdapter(TTSPort):
-    def __init__(self, api_key: str, model: str = "gemini-2.5-flash-preview-tts") -> None:
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "gemini-2.5-flash-preview-tts",
+        base_url: str = "https://generativelanguage.googleapis.com/v1beta",
+    ) -> None:
         self._model = model
         self._client = httpx.AsyncClient(
-            base_url="https://generativelanguage.googleapis.com/v1beta",
+            base_url=base_url,
             headers={"x-goog-api-key": api_key},
             timeout=30.0,
         )

--- a/adapters/tts/google_tts.py
+++ b/adapters/tts/google_tts.py
@@ -14,9 +14,11 @@ _FORMAT_MAP = {
 
 
 class GoogleTTSAdapter(TTSPort):
-    def __init__(self, api_key: str) -> None:
+    def __init__(
+        self, api_key: str, base_url: str = "https://texttospeech.googleapis.com/v1"
+    ) -> None:
         self._client = httpx.AsyncClient(
-            base_url="https://texttospeech.googleapis.com/v1",
+            base_url=base_url,
             params={"key": api_key},
             timeout=30.0,
         )

--- a/config/settings.py
+++ b/config/settings.py
@@ -10,10 +10,13 @@ class Settings(BaseSettings):
     tts_provider: str = "mock"  # "mock" | "google_tts" | "gemini_tts"
 
     openai_api_key: str = ""
+    openai_base_url: str = "https://api.openai.com/v1"
     gemini_api_key: str = ""
+    gemini_base_url: str = "https://generativelanguage.googleapis.com/v1beta"
     gemini_model: str = "gemini-2.5-flash-image"
     gemini_tts_model: str = "gemini-2.5-flash-preview-tts"
     google_tts_credentials: str = ""
+    google_tts_base_url: str = "https://texttospeech.googleapis.com/v1"
 
     host: str = "0.0.0.0"
     port: int = 8100

--- a/main.py
+++ b/main.py
@@ -21,16 +21,24 @@ from services.image_service import ImageService
 from services.tts_service import TTSService
 
 _IMAGE_ADAPTERS: dict[str, Callable[[], ImageGeneratorPort]] = {
-    "openai_dalle": lambda: OpenAIDalleAdapter(api_key=settings.openai_api_key),
+    "openai_dalle": lambda: OpenAIDalleAdapter(
+        api_key=settings.openai_api_key, base_url=settings.openai_base_url
+    ),
     "gemini": lambda: GeminiImageAdapter(
-        api_key=settings.gemini_api_key, model=settings.gemini_model
+        api_key=settings.gemini_api_key,
+        model=settings.gemini_model,
+        base_url=settings.gemini_base_url,
     ),
 }
 
 _TTS_ADAPTERS: dict[str, Callable[[], TTSPort]] = {
-    "google_tts": lambda: GoogleTTSAdapter(api_key=settings.google_tts_credentials),
+    "google_tts": lambda: GoogleTTSAdapter(
+        api_key=settings.google_tts_credentials, base_url=settings.google_tts_base_url
+    ),
     "gemini_tts": lambda: GeminiTTSAdapter(
-        api_key=settings.gemini_api_key, model=settings.gemini_tts_model
+        api_key=settings.gemini_api_key,
+        model=settings.gemini_tts_model,
+        base_url=settings.gemini_base_url,
     ),
 }
 


### PR DESCRIPTION
## Summary
- All provider base URLs (`OPENAI_BASE_URL`, `GEMINI_BASE_URL`, `GOOGLE_TTS_BASE_URL`) are now configurable via env vars
- Adapter constructors accept `base_url` parameter, defaults unchanged
- Updated `.env.example` with the new settings

Closes #8

Note: The `jwt_secret` default was already fixed in a prior PR (min_length=32 validation, no weak default). No real API keys were found in committed code.

## Test plan
- [x] All 54 tests pass
- [x] Linting passes
- [x] Default behavior unchanged (same URLs as before when env vars not set)