### PR TITLE
fix: log startup warning when TTS provider health check fails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ GEMINI_API_KEY=
 GEMINI_MODEL=gemini-2.5-flash-image
 
 # TTS provider: "mock" | "google_tts" | "gemini_tts"
+# Recommended: gemini_tts (reuses GEMINI_API_KEY, no separate credentials needed)
+# google_tts requires a separate Google Cloud API key with Text-to-Speech API enabled
 TTS_PROVIDER=mock
 GOOGLE_TTS_CREDENTIALS=
 GEMINI_TTS_MODEL=gemini-2.5-flash-preview-tts

--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 
@@ -19,6 +20,8 @@ from core.exceptions import AuthenticationError, MalformedClaimError, ProviderEr
 from core.ports import ImageGeneratorPort, TTSPort
 from services.image_service import ImageService
 from services.tts_service import TTSService
+
+logger = logging.getLogger(__name__)
 
 _IMAGE_ADAPTERS: dict[str, Callable[[], ImageGeneratorPort]] = {
     "openai_dalle": lambda: OpenAIDalleAdapter(api_key=settings.openai_api_key),
@@ -45,6 +48,21 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     app.state.image_service = ImageService(image_adapter)
     app.state.tts_service = TTSService(tts_adapter)
+
+    image_ok = await image_adapter.health_check()
+    tts_ok = await tts_adapter.health_check()
+    if not image_ok:
+        logger.warning(
+            "Image provider '%s' failed health check at startup", settings.image_provider
+        )
+    if not tts_ok:
+        logger.warning(
+            "TTS provider '%s' failed health check at startup — TTS requests will return 502. "
+            "If using google_tts, ensure GOOGLE_TTS_CREDENTIALS has Cloud TTS API enabled, "
+            "or switch to TTS_PROVIDER=gemini_tts to use the Gemini API key instead.",
+            settings.tts_provider,
+        )
+
     yield
 
 


### PR DESCRIPTION
## Summary
- Adds startup health check for both image and TTS providers
- Logs a warning with actionable guidance if a provider fails (specifically suggests switching to `gemini_tts` when `google_tts` fails due to missing API permissions)
- Updates `.env.example` to recommend `gemini_tts` over `google_tts`

Closes #1

## Context
The `google_tts` provider returns 502 when the configured API key is a Gemini key without Cloud TTS permissions. The `gemini_tts` adapter (already in the codebase) works with the same Gemini API key. The fix on the deployment side is `TTS_PROVIDER=gemini_tts`.

## Test plan
- [x] All 54 tests pass
- [x] Lint clean