### PR TITLE
fix: health endpoint returns 503 when degraded, add image size limits

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
 
 from api.dependencies import get_image_service, get_tts_service
 from api.schemas import HealthResponse
@@ -14,9 +15,14 @@ router = APIRouter(tags=["health"])
 async def health(
     image_svc: ImageService = Depends(get_image_service),
     tts_svc: TTSService = Depends(get_tts_service),
-) -> HealthResponse:
+) -> JSONResponse:
     image_ok = await image_svc.health_check()
     tts_ok = await tts_svc.health_check()
     providers = {"image": image_ok, "tts": tts_ok}
-    status = "healthy" if all(providers.values()) else "degraded"
-    return HealthResponse(status=status, providers=providers)
+    is_healthy = all(providers.values())
+    status = "healthy" if is_healthy else "degraded"
+    data = HealthResponse(status=status, providers=providers)
+    return JSONResponse(
+        content=data.model_dump(),
+        status_code=200 if is_healthy else 503,
+    )

--- a/api/health.py
+++ b/api/health.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Depends, Response
 
 from api.dependencies import get_image_service, get_tts_service
 from api.schemas import HealthResponse
@@ -13,16 +12,14 @@ router = APIRouter(tags=["health"])
 
 @router.get("/api/v1/health", response_model=HealthResponse)
 async def health(
+    response: Response,
     image_svc: ImageService = Depends(get_image_service),
     tts_svc: TTSService = Depends(get_tts_service),
-) -> JSONResponse:
+) -> HealthResponse:
     image_ok = await image_svc.health_check()
     tts_ok = await tts_svc.health_check()
     providers = {"image": image_ok, "tts": tts_ok}
     is_healthy = all(providers.values())
     status = "healthy" if is_healthy else "degraded"
-    data = HealthResponse(status=status, providers=providers)
-    return JSONResponse(
-        content=data.model_dump(),
-        status_code=200 if is_healthy else 503,
-    )
+    response.status_code = 200 if is_healthy else 503
+    return HealthResponse(status=status, providers=providers)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -2,13 +2,13 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
-PositiveInt = Annotated[int, Field(gt=0)]
+ImageDimension = Annotated[int, Field(gt=0, le=4096)]
 
 
 class ImageGenerateRequest(BaseModel):
     prompt: Annotated[str, Field(min_length=1, max_length=500)]
     style: Literal["pictogram", "realistic", "cartoon"] = "pictogram"
-    size: tuple[PositiveInt, PositiveInt] = (512, 512)
+    size: tuple[ImageDimension, ImageDimension] = (512, 512)
     format: Literal["png", "webp"] = "png"
 
 

--- a/services/image_service.py
+++ b/services/image_service.py
@@ -47,6 +47,6 @@ class ImageService:
             return result
         resized = img.resize(target_size, Image.Resampling.LANCZOS)
         buf = io.BytesIO()
-        pil_fmt = "PNG" if result.format == "png" else "WEBP"
+        pil_fmt = {"png": "PNG", "webp": "WEBP"}.get(result.format, result.format.upper())
         resized.save(buf, format=pil_fmt)
         return replace(result, image_data=buf.getvalue())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,26 @@ def test_health(client: TestClient) -> None:
     assert data["providers"]["tts"] is True
 
 
+def test_health_degraded_returns_503(client: TestClient) -> None:
+    with patch(
+        "services.image_service.ImageService.health_check",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        resp = client.get("/api/v1/health")
+    assert resp.status_code == 503
+    assert resp.json()["status"] == "degraded"
+
+
+def test_generate_image_size_too_large(client: TestClient, auth_header: dict[str, str]) -> None:
+    resp = client.post(
+        "/api/v1/generate/image",
+        json={"prompt": "test", "size": [5000, 5000]},
+        headers=auth_header,
+    )
+    assert resp.status_code == 422
+
+
 def test_generate_image_requires_auth(client: TestClient) -> None:
     resp = client.post("/api/v1/generate/image", json={"prompt": "test"})
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- **Health endpoint:** returns 503 when any provider is down (was 200 with `"degraded"` in JSON body)
- **Image size limits:** dimensions capped at 4096px via `le=4096` on schema — prevents PIL from attempting massive memory allocations
- **`_ensure_size` format handling:** replaced fragile `if/else` with explicit format mapping + dynamic fallback

Closes #23

## Test plan
- [x] All 67 tests pass (2 new)
- [x] 0 warnings
- [x] `ruff check .` clean
- [x] `mypy .` clean
- [x] `test_health_degraded_returns_503` — mock failing provider, verify 503
- [x] `test_generate_image_size_too_large` — request 5000x5000, verify 422