### PR TITLE
chore: add adapter logging, expand ruff rules, simplify auth dependency

### DIFF
--- a/api/image.py
+++ b/api/image.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Request
 
 from api.dependencies import get_image_service
 from api.schemas import ImageGenerateRequest, ImageGenerateResponse
-from config.auth import get_org_roles
+from config.auth import get_current_user
 from config.rate_limit import limiter
 from core.types import ImageGenerationRequest
 from services.image_service import ImageService
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/api/v1/generate", tags=["image"])
 async def generate_image(
     request: Request,  # noqa: ARG001  # required by slowapi limiter
     body: ImageGenerateRequest,
-    _org_roles: dict[str, str] = Depends(get_org_roles),
+    _user: dict[str, object] = Depends(get_current_user),
     service: ImageService = Depends(get_image_service),
 ) -> ImageGenerateResponse:
     gen_request = ImageGenerationRequest(

--- a/api/image.py
+++ b/api/image.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 
@@ -19,7 +20,7 @@ router = APIRouter(prefix="/api/v1/generate", tags=["image"])
 async def generate_image(
     request: Request,  # noqa: ARG001  # required by slowapi limiter
     body: ImageGenerateRequest,
-    _user: dict[str, object] = Depends(get_current_user),
+    _user: dict[str, Any] = Depends(get_current_user),
     service: ImageService = Depends(get_image_service),
 ) -> ImageGenerateResponse:
     gen_request = ImageGenerationRequest(

--- a/api/tts.py
+++ b/api/tts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+from typing import Any
 
 from fastapi import APIRouter, Depends, Request
 
@@ -19,7 +20,7 @@ router = APIRouter(prefix="/api/v1/tts", tags=["tts"])
 async def synthesize(
     request: Request,  # noqa: ARG001  # required by slowapi limiter
     body: TTSSynthesizeRequest,
-    _user: dict[str, object] = Depends(get_current_user),
+    _user: dict[str, Any] = Depends(get_current_user),
     service: TTSService = Depends(get_tts_service),
 ) -> TTSSynthesizeResponse:
     tts_request = TTSRequest(
@@ -41,7 +42,7 @@ async def synthesize(
 @router.get("/voices", response_model=list[VoiceResponse])
 async def list_voices(
     language: str | None = None,
-    _user: dict[str, object] = Depends(get_current_user),
+    _user: dict[str, Any] = Depends(get_current_user),
     service: TTSService = Depends(get_tts_service),
 ) -> list[VoiceResponse]:
     voices = await service.list_voices(language)

--- a/api/tts.py
+++ b/api/tts.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, Request
 
 from api.dependencies import get_tts_service
 from api.schemas import TTSSynthesizeRequest, TTSSynthesizeResponse, VoiceResponse
-from config.auth import get_org_roles
+from config.auth import get_current_user
 from config.rate_limit import limiter
 from core.types import TTSRequest
 from services.tts_service import TTSService
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/api/v1/tts", tags=["tts"])
 async def synthesize(
     request: Request,  # noqa: ARG001  # required by slowapi limiter
     body: TTSSynthesizeRequest,
-    _org_roles: dict[str, str] = Depends(get_org_roles),
+    _user: dict[str, object] = Depends(get_current_user),
     service: TTSService = Depends(get_tts_service),
 ) -> TTSSynthesizeResponse:
     tts_request = TTSRequest(
@@ -41,7 +41,7 @@ async def synthesize(
 @router.get("/voices", response_model=list[VoiceResponse])
 async def list_voices(
     language: str | None = None,
-    _org_roles: dict[str, str] = Depends(get_org_roles),
+    _user: dict[str, object] = Depends(get_current_user),
     service: TTSService = Depends(get_tts_service),
 ) -> list[VoiceResponse]:
     voices = await service.list_voices(language)

--- a/config/auth.py
+++ b/config/auth.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import jwt
@@ -6,7 +5,7 @@ from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from config.settings import settings
-from core.exceptions import AuthenticationError, MalformedClaimError
+from core.exceptions import AuthenticationError
 
 _bearer = HTTPBearer()
 
@@ -23,14 +22,3 @@ def get_current_user(
 ) -> dict[str, Any]:
     payload = decode_jwt(credentials.credentials)
     return payload
-
-
-def get_org_roles(user: dict[str, Any] = Depends(get_current_user)) -> dict[str, str]:
-    raw = user.get("org_roles", {})
-    if isinstance(raw, str):
-        try:
-            raw = json.loads(raw)
-        except (json.JSONDecodeError, TypeError) as e:
-            raise MalformedClaimError("Malformed org_roles claim") from e
-    result: dict[str, str] = raw
-    return result

--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -14,9 +14,5 @@ class AuthenticationError(GirafAIError):
     """Raised when JWT validation fails."""
 
 
-class MalformedClaimError(GirafAIError):
-    """Raised when a JWT claim has an unexpected format."""
-
-
 class UnsupportedFormatError(GirafAIError):
     """Raised when a requested format is not supported by the active provider."""

--- a/core/http.py
+++ b/core/http.py
@@ -1,5 +1,6 @@
 """Shared HTTP utilities for provider adapters."""
 
+import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Literal
@@ -7,6 +8,8 @@ from typing import Literal
 import httpx
 
 from core.exceptions import ProviderError
+
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
@@ -22,7 +25,10 @@ async def provider_request(
         resp = await getattr(client, method)(url, **kwargs)
         resp.raise_for_status()
     except httpx.HTTPStatusError as e:
+        logger.error("%s: HTTP %s for %s %s", provider, e.response.status_code, method.upper(), url)
         raise ProviderError(provider, f"HTTP {e.response.status_code}") from e
     except httpx.RequestError as e:
+        logger.error("%s: request failed for %s %s: %s", provider, method.upper(), url, e)
         raise ProviderError(provider, str(e)) from e
+    logger.debug("%s: %s %s -> %s", provider, method.upper(), url, resp.status_code)
     yield resp

--- a/main.py
+++ b/main.py
@@ -23,7 +23,6 @@ from config.rate_limit import limiter
 from config.settings import settings
 from core.exceptions import (
     AuthenticationError,
-    MalformedClaimError,
     ProviderError,
     UnsupportedFormatError,
 )
@@ -119,11 +118,6 @@ if settings.cors_allowed_origins:
 
 @app.exception_handler(AuthenticationError)
 async def auth_error_handler(_request: Request, exc: AuthenticationError) -> JSONResponse:
-    return JSONResponse(status_code=401, content={"detail": str(exc)})
-
-
-@app.exception_handler(MalformedClaimError)
-async def malformed_claim_handler(_request: Request, exc: MalformedClaimError) -> JSONResponse:
     return JSONResponse(status_code=401, content={"detail": str(exc)})
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,11 @@ target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "N", "W", "UP"]
+select = ["E", "F", "I", "N", "W", "UP", "B", "A", "RUF", "SIM", "ARG"]
+ignore = [
+    "B008",  # Depends() in defaults is idiomatic FastAPI
+    "B027",  # Empty methods in ABCs are intentional default no-ops
+]
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
## Summary
- **Logging:** Add debug/error logging to `core/http.py` `provider_request()` — all adapter HTTP calls now log method, URL, status on success (debug) and errors (error)
- **Ruff rules:** Expand from `E,F,I,N,W,UP` to also include `B` (bugbear), `A` (builtins), `RUF`, `SIM` (simplify), `ARG` (unused args). Ignore `B008` (FastAPI Depends pattern) and `B027` (intentional ABC no-ops)
- **Auth cleanup:** Replace unused `get_org_roles` dependency with `get_current_user` in image/TTS endpoints — org_roles were fetched but never used for authorization

Closes #25

## Test plan
- [x] All 67 tests pass, 0 warnings
- [x] `ruff check .` clean with expanded ruleset
- [x] `mypy .` clean