### PR TITLE
feat: add plapre_cpu TTS provider

### DIFF
--- a/adapters/tts/plapre.py
+++ b/adapters/tts/plapre.py
@@ -10,14 +10,20 @@ PLAPRE_SAMPLE_RATE = 24000
 
 
 class PlapreAdapter(TTSPort):
-    """TTS adapter for Plapre Danish TTS running on a GPU server."""
+    """TTS adapter for Plapre Danish TTS (GPU or CPU server)."""
 
     supported_formats = frozenset({"wav"})
 
-    def __init__(self, base_url: str = "http://localhost:8200") -> None:
+    def __init__(
+        self,
+        base_url: str = "http://localhost:8200",
+        provider: TTSProvider = TTSProvider.PLAPRE,
+        timeout: float = 60.0,
+    ) -> None:
+        self._provider = provider
         self._client = httpx.AsyncClient(
             base_url=base_url,
-            timeout=60.0,  # TTS generation can be slow
+            timeout=timeout,
         )
 
     async def synthesize(self, request: TTSRequest) -> TTSResult:
@@ -26,7 +32,7 @@ class PlapreAdapter(TTSPort):
             body["speaker"] = request.voice
 
         async with provider_request(
-            self._client, "post", "/v1/audio/speech", TTSProvider.PLAPRE, json=body
+            self._client, "post", "/v1/audio/speech", self._provider, json=body
         ) as resp:
             pcm = resp.content
         wav = pcm_to_wav(pcm)
@@ -36,18 +42,13 @@ class PlapreAdapter(TTSPort):
             audio_data=wav,
             format="wav",
             duration_ms=duration_ms,
-            provider=TTSProvider.PLAPRE,
+            provider=self._provider,
         )
 
     async def list_voices(self, language: str | None = None) -> list[VoiceInfo]:
-        async with provider_request(
-            self._client, "get", "/v1/speakers", TTSProvider.PLAPRE
-        ) as resp:
+        async with provider_request(self._client, "get", "/v1/speakers", self._provider) as resp:
             speakers = resp.json().get("speakers", [])
-        voices = [
-            VoiceInfo(id=name, name=name, language="da")
-            for name in speakers
-        ]
+        voices = [VoiceInfo(id=name, name=name, language="da") for name in speakers]
         if language:
             voices = [v for v in voices if v.language == language]
         return voices

--- a/config/settings.py
+++ b/config/settings.py
@@ -18,6 +18,7 @@ class Settings(BaseSettings):
     gemini_model: str = "gemini-2.5-flash-image"
     gemini_tts_model: str = "gemini-2.5-flash-preview-tts"
     plapre_base_url: str = "http://localhost:8200"
+    plapre_cpu_base_url: str = "http://localhost:8201"
     imagegen_base_url: str = "http://localhost:8300"
 
     cors_allowed_origins: list[str] = []

--- a/core/providers.py
+++ b/core/providers.py
@@ -14,3 +14,4 @@ class TTSProvider(StrEnum):
     MOCK = "mock"
     GEMINI_TTS = "gemini_tts"
     PLAPRE = "plapre"
+    PLAPRE_CPU = "plapre_cpu"

--- a/main.py
+++ b/main.py
@@ -51,6 +51,11 @@ _TTS_ADAPTERS: dict[TTSProvider, Callable[[], TTSPort]] = {
         base_url=settings.gemini_base_url,
     ),
     TTSProvider.PLAPRE: lambda: PlapreAdapter(base_url=settings.plapre_base_url),
+    TTSProvider.PLAPRE_CPU: lambda: PlapreAdapter(
+        base_url=settings.plapre_cpu_base_url,
+        provider=TTSProvider.PLAPRE_CPU,
+        timeout=120.0,
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Parameterize `PlapreAdapter` so a single class can drive both the GPU plapre server and the CPU-only `plapreCPU` fork.
- Add `TTSProvider.PLAPRE_CPU` and `settings.plapre_cpu_base_url` (default `:8201`).
- Wire the new provider in `main.py` with a 120s timeout (CPU inference is ~2x slower than GPU).
- Resolves aau-giraf/giraf-ai#35 — lets Strato run `TTS_PROVIDER=plapre_cpu` against a host-side `plapre-cpu-serve` process.

## Test plan
- [ ] `uv run pytest` passes locally.
- [ ] `uv run ruff check . && uv run mypy .` clean.
- [ ] After merge, Strato `git pull` + `docker compose up -d --build giraf-ai` starts without pydantic validation errors.
- [ ] `/api/v1/tts/synthesize` against a Danish prompt returns a 24 kHz mono WAV.